### PR TITLE
Added support for eth0 when wlan0 is not available

### DIFF
--- a/global_conf_US915_SB2.json
+++ b/global_conf_US915_SB2.json
@@ -15,7 +15,7 @@
         "radio_1": {
             "enable": true,
             "type": "SX1257",
-            "freq": 923000000,
+            "freq": 905000000,
             "rssi_offset": -166.0,
             "tx_enable": false
         },


### PR DESCRIPTION
Support for eth0 when configuring Gateway ID. This is handy if implementation is done on RaspberryPi 2+ and not a PiZero.